### PR TITLE
Print body as a concatenation of the common labels.

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,7 +12,6 @@ type ReceiverConf struct {
 	Provider string
 	To       []string
 	From     string
-	Text     string
 }
 
 var config struct {

--- a/config.yaml
+++ b/config.yaml
@@ -11,5 +11,4 @@ receivers:
     to:
       - '+31612345678'
     from: 'Sachet'
-    text: 'Something was sent from the Prometheus Alertmanager!'
 

--- a/example.json
+++ b/example.json
@@ -1,5 +1,5 @@
 {  
-   "receiver":"team-sms",
+   "receiver":"kumina-reports",
    "status":"firing",
    "alerts":[  
       {  


### PR DESCRIPTION
With the existing code we're having the issue that it ends up creating
empty message bodies. These are rejected by MessageBird.

With this change we simply look at all of the labels that are common
across the entire message. As AlertManager generates a single request
for every different alert name, it means in practice that you get
something along the lines of:

  TooManyGophers | localhost:9091 | pushprom | codelab-monitor |
  gophers is bigger than 10

By sending a single SMS, we also cut down on costs.